### PR TITLE
svg invertex Y axis causes issue with faceOrders

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,11 @@
     </div>
     <div>
         <svg id="main">
-            <svg id="flat" transform="translate(0 1000) scale(1 -1)"></svg>
-            <svg id="cell" transform="translate(0 1000) scale(1 -1)"></svg>
-            <svg id="fold" transform="translate(0 1000) scale(1 -1)"></svg>
+            <g transform="translate(0 1000) scale(1 -1)">
+                <svg id="flat"></svg>
+                <svg id="cell"></svg>
+                <svg id="fold"></svg>
+            </g>
         </svg>
     </div>
     <div>© Jason S. Ku 2022</div>

--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
     </div>
     <div>
         <svg id="main">
-            <svg id="flat"></svg>
-            <svg id="cell"></svg>
-            <svg id="fold"></svg>
+            <svg id="flat" transform="translate(0 1000) scale(1 -1)"></svg>
+            <svg id="cell" transform="translate(0 1000) scale(1 -1)"></svg>
+            <svg id="fold" transform="translate(0 1000) scale(1 -1)"></svg>
         </svg>
     </div>
     <div>© Jason S. Ku 2022</div>

--- a/script.js
+++ b/script.js
@@ -459,7 +459,7 @@ const SOLVER = {    // STATE SOLVER
     edges_Ff_2_FO: (edges, Ff) => {
         return edges.map((k) => {
             const [f1, f2] = M.decode(k);
-            return [f1, f2, (Ff[f2] ? 1 : -1)];
+            return [f1, f2, (Ff[f2] ? -1 : 1)];
         });
     },
     CF_edges_flip_2_CD: (CF, edges) => {
@@ -1808,7 +1808,7 @@ const SVG = {   // DRAWING
     },
     draw_label: (svg, [x, y], color, i) => {
         const t = SVG.append("text", svg, {
-            x: x, y: y, "fill": color, "font-size": "15pt"});
+            "fill": color, "font-size": "15pt", "transform": `translate(${x} ${y}) scale(1 -1)`});
         t.innerHTML = i;
         return t;
     },


### PR DESCRIPTION
There is an issue that arises from the inverted Y axis in the SVG rendering, which leads to the faceOrders being incorrect in the exported FOLD state. here is a test FOLD file to demonstrate the issue. two faces separated by a valley fold. counter-clockwise winding. according to the FOLD spec, in this situation, the faceOrder between face 0 and 1 should result in a +1, no matter which face comes first in the faceOrder, both are similarly above each other's normal in the case of a valley fold.

however, flat-folder will output a -1 relationship, `[1,0,-1]`. Which, looks correct if you are inverting the Y axis in the rendering (the valley fold looks like a valley fold), but the data itself is incorrect. And, the output looks incorrect in other renderers (a valley results in a mountain fold)

I can think of a couple solutions:

- don't touch the renderer, however, when asked to export the folded state FOLD file, quickly invert index [2] of each of the faceOrders, then export.
- invert the SVG renderer (which I did in the pull request), in which the SVG is given a transform, which would make the text appear upside down, so the text is similarly given a transform.

The addition of the group element was intentional and is necessary for compatibility across all browsers. It should be possible to apply a transform to the SVG directly, it is described in the SVG 2.0 spec, but all 3 major browsers are still not consisstent. However, a transform on a group is consistent.

I tested 3 browsers (Chrome, Firefox, Safari), show text, touch interface. all of this seems to work.

```json
{
	"file_spec": 1.1,
	"file_author": "Kraft",
	"file_classes": ["singleModel"],
	"frame_attributes": ["2D"],
	"frame_title": "one fold",
	"frame_classes": ["creasePattern"],
	"vertices_coords": [[0,0],[0.6,0],[1,0],[1,1],[0.4,1],[0,1]],
	"edges_vertices": [[0,1],[1,2],[2,3],[3,4],[4,5],[5,0],[1,4]],
	"edges_assignment": ["B","B","B","B","B","B","V"],
	"faces_vertices": [[0,1,4,5],[1,2,3,4]],
	"file_frames": [{
		"frame_classes": ["foldedForm"],
		"frame_parent": 0,
		"frame_inherit": true,
		"vertices_coords": [
			[0,0],
			[0.6,0],
			[0.2307692307692307,-0.15384615384615383],
			[-0.15384615384615388,0.7692307692307692],
			[0.4,1],
			[0,1]
		],
		"faceOrders": [
			[0,1,1]
		]
	}]
}
```