### PR TITLE
Allow lowercase hex colors for edge assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ or [Twitter](https://twitter.com/_flatfolder_).
           (assignment `"U"`), unless its `"style"` attribute contains a
           `"stroke"` whose value is one of `["red", "blue", "gray"]`
           corresponding to `["M", "V", "F"]` assignments respectively;
-        - will also accept values `["#FF0000", "#0000FF", "#808080"]`.
+        - will also accept values `["#FF0000", "#0000FF", "#808080"]`, uppercase or lowercase.
     - For FOLD format:
         - Import requires two properties:
             - `vertices_coords`

--- a/src/io.js
+++ b/src/io.js
@@ -90,9 +90,9 @@ export const IO = {    // INPUT-OUTPUT
                 const attr = parts[0].trim();
                 const  val = parts[1].trim();
                 if (attr == "stroke") {
-                    if (val == "red" || val == "#FF0000") {
+                    if (val == "red" || val == "#FF0000" || val == "#ff0000") {
                         a = "M";
-                    } else if (val == "blue" || val == "#0000FF") {
+                    } else if (val == "blue" || val == "#0000FF" || val == "#0000ff") {
                         a = "V";
                     } else if (val == "gray" || val == "#808080") {
                         a = "F";


### PR DESCRIPTION
Inkscape uses lowercase hex colors